### PR TITLE
feat: allow action-sepcific metadata

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,8 @@ export class Action {
     action: Action | undefined,
     type: string,
     payload?: any,
-    appId?: string
+    appId?: string,
+    metadata?: any
   ) {
     if (action === undefined) {
       if (appId === undefined) {
@@ -25,13 +26,13 @@ export class Action {
 
     const nextMeta = Meta.advance(action.meta, `created from ${action.type}`);
 
-    return new Action(action.appId, type, payload, nextMeta);
+    return new Action(action.appId, type, payload, nextMeta, metadata);
   }
 
   public static augment(action: Action, properties: AugmentProps) {
     const nextMeta = Meta.augment(action.meta, properties);
 
-    return new Action(action.appId, action.type, action.payload, nextMeta);
+    return new Action(action.appId, action.type, action.payload, nextMeta, action.metadata);
   }
 
   public static merge(actionMap: ActionTypeMap) {
@@ -59,13 +60,15 @@ export class Action {
   public readonly appId: string;
   public readonly payload?: any;
   public readonly meta: Meta;
+  public readonly metadata: any;
   public slim: boolean = false;
 
   constructor(
     appId: string,
     type: string,
     payload?: any,
-    meta?: Meta | Record<string, any>
+    meta?: Meta | Record<string, any>,
+    metadata?: any,
   ) {
     if (typeof appId !== "string" || appId.length === 0) {
       throw new Error("a valid app id must be provided");
@@ -74,6 +77,7 @@ export class Action {
     this.appId = appId;
     this.type = type;
     this.payload = payload;
+    this.metadata = metadata
 
     if (meta instanceof Meta) {
       this.meta = meta;
@@ -91,8 +95,9 @@ export class Action {
   public toJSON() {
     return {
       meta: this.meta.toJSON(this.slim),
+      metadata: this.metadata,
       payload: prune(this.payload),
-      type: this.type
+      type: this.type,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ export type AugmentProps = Partial<IMetaOpts>;
 export type ActionTypeMap = Record<string, Action>;
 
 export function make(appId: string) {
-  return (type: string, payload?: any, meta?: any) =>
-    new Action(appId, type, payload, meta);
+  return (type: string, payload?: any, meta?: any, metadata?: any) =>
+    new Action(appId, type, payload, meta, metadata);
 }
 
 export function next(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,14 +3,16 @@ import test, { Test } from "tape";
 import { augment, AugmentProps, make, next } from "../src";
 
 test("make creates a new action", (t: Test) => {
-  t.plan(3);
+  t.plan(4);
 
   const payload = { key: "value" };
-  const action = make("app")("test", payload);
+  const metadata = { total: 42 }
+  const action = make("app")("test", payload, undefined, metadata);
 
   t.equal(action.type, "test", "type is correct");
   t.equal(action.appId, "app", "app id is correct");
   t.deepEqual(action.payload, payload, "payload is correct");
+  t.deepEqual(action.metadata, metadata, "metadata is correct");
 });
 
 test("next creates a new action advancing meta", (t: Test) => {


### PR DESCRIPTION
Closes #1 
Presently, the `meta` keyword is reserved internally, so something with `action.meta` will get overwritten. The goal here is to allow the consuming app to specify `action.metadata`.